### PR TITLE
Fix NRE in DeferredContentFrameworkElementFactory.CreateElement

### DIFF
--- a/src/EditorFeatures/Core/Implementation/IntelliSense/QuickInfo/Providers/AbstractQuickInfoProvider.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/QuickInfo/Providers/AbstractQuickInfoProvider.cs
@@ -114,8 +114,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.QuickInfo
                 typeParameterMap: CreateClassifiableDeferredContent(typeParameterMap),
                 anonymousTypes: CreateClassifiableDeferredContent(anonymousTypes),
                 usageText: CreateClassifiableDeferredContent(usageText),
-                exceptionText: CreateClassifiableDeferredContent(exceptionText),
-                capturesText: null);
+                exceptionText: CreateClassifiableDeferredContent(exceptionText));
         }
 
         protected IDeferredQuickInfoContent CreateGlyphDeferredContent(ISymbol symbol)


### PR DESCRIPTION
Constructing the QuickInfoDisplayDeferredContent with `capturesText: null` causes a NRE when 
creating elements for the QuickInfo popup. Instead use the constructor overload that sets `capturesText`
to an empty content.

This fixes #26672.